### PR TITLE
deploy(review-bot): bump to v0.1.14

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: review-bot
-          image: ghcr.io/anchavesb/review-bot:v0.1.13
+          image: ghcr.io/anchavesb/review-bot:v0.1.14
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Bumps review-bot to v0.1.14 which uses an explicit stable 'v1' base_url for Gemini models to resolve persistent 404 errors.