### PR TITLE
Update review-bot to v0.2.0

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: review-bot
-          image: ghcr.io/anchavesb/review-bot:v0.1.19
+          image: ghcr.io/anchavesb/review-bot:v0.2.0
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Updating review-bot image to v0.2.0 in dal-navy-core-1. This version includes the agentic upgrade (full-file context, verification pass, discovery loop) and rate-limit fixes.