### PR TITLE
Update review-bot to v0.2.2

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/review-bot/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: review-bot
-          image: ghcr.io/anchavesb/review-bot:v0.2.1
+          image: ghcr.io/anchavesb/review-bot:v0.2.2
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Updating review-bot image to v0.2.2 to fix 404 errors.