### PR TITLE
fix(navy): nest traefik redirections under http block

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-2/values/traefik-private/values.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-2/values/traefik-private/values.yaml
@@ -20,10 +20,11 @@ providers:
 ports:
   web:
     port: 80
-    redirections:
-      entryPoint:
-        to: websecure
-        scheme: https
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
   websecure:
     asDefault: true
     port: 443

--- a/sites/navy/clusters/dal-navy-core-1/wave-2/values/traefik-public/values.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-2/values/traefik-public/values.yaml
@@ -20,10 +20,11 @@ providers:
 ports:
   web:
     port: 80
-    redirections:
-      entryPoint:
-        to: websecure
-        scheme: https
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
   websecure:
     asDefault: true
     port: 443


### PR DESCRIPTION
Nests web port redirections under the http block to align with Traefik Helm chart v26+ schema, fixing ArgoCD manifest generation errors.