### PR TITLE
deploy(dolores-brain): bump to v0.6.1 for cloudscraper support

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/dolores-brain/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/dolores-brain/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: dolores-brain
-          image: ghcr.io/anchavesb/dolores-brain:v0.6.0
+          image: ghcr.io/anchavesb/dolores-brain:v0.6.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Bumps dolores-brain container image to v0.6.1 to roll out the cloudscraper Cloudflare bypass endpoint.