### PR TITLE
fix(whatsapp): disable database for evolution-api

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -34,13 +34,11 @@ spec:
                   name: whatsapp-secrets
                   key: api-key
             
-            # SQLite Database settings (stored on our PVC)
+            # Database disabled, local files only
             - name: DATABASE_ENABLED
-              value: "true"
+              value: "false"
             - name: DATABASE_PROVIDER
-              value: "sqlite"
-            - name: DATABASE_CONNECTION_URI
-              value: "file:///evolution/instances/database.sqlite"
+              value: "postgresql"
             - name: DATABASE_SAVE_DATA_INSTANCE
               value: "true"
 


### PR DESCRIPTION
Disables external database and configures the DATABASE_PROVIDER to postgresql to pass the startup checks.