### PR TITLE
fix(whatsapp): disable redis cache and enable local cache

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -47,6 +47,12 @@ spec:
             - name: DATABASE_SAVE_DATA_INSTANCE
               value: "true"
 
+            # Cache Configuration (disable Redis, enable local cache)
+            - name: CACHE_REDIS_ENABLED
+              value: "false"
+            - name: CACHE_LOCAL_ENABLED
+              value: "true"
+
             # Global Webhook configuration (calls n8n internally)
             - name: WEBHOOK_GLOBAL_ENABLED
               value: "true"


### PR DESCRIPTION
Disables the Redis cache dependency in evolution-api and enables local/in-memory caching instead to resolve the continuous redis disconnection loop.