### PR TITLE
fix(whatsapp): allow egress to world on port 80, 443, 5222

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -41,15 +41,18 @@ spec:
             dns:
               - matchPattern: "*"
               
-    # 3. Allow outbound connections ONLY to WhatsApp and Meta domains
-    - toFQDNs:
-        - matchPattern: "*.whatsapp.com"
-        - matchPattern: "*.whatsapp.net"
-        - matchPattern: "*.fbcdn.net"
+    # 3. Allow outbound connections to the internet (for WhatsApp Web server WebSocket connections)
+    - toEntities:
+        - world
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
+            - port: "80"
+              protocol: TCP
+            - port: "5222"
+              protocol: TCP
+
               
     # 4. Allow connecting to the local Postgres database
     - toEndpoints:


### PR DESCRIPTION
Allows the evolution-api pod to connect outbound to the internet (world entity) on ports 80, 443, and 5222, resolving potential websocket and connection setup drops while still restricting access to other internal cluster resources.