### PR TITLE
fix(whatsapp): allow TCP port 53 for DNS and unrestrict world egress ports

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -37,21 +37,15 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+            - port: "53"
+              protocol: TCP
           rules:
             dns:
               - matchPattern: "*"
               
-    # 3. Allow outbound connections to the internet (for WhatsApp Web server WebSocket connections)
+    # 3. Allow outbound connections to the internet (for WhatsApp Web server connections)
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-            - port: "80"
-              protocol: TCP
-            - port: "5222"
-              protocol: TCP
 
               
     # 4. Allow connecting to the local Postgres database


### PR DESCRIPTION
Allows TCP port 53 for DNS fallback and removes port restrictions on the world egress entity to resolve potential noise handshake decode failures and socket drops in the evolution-api container.