### PR TITLE
fix(whatsapp): set emulated whatsapp version to 2.3000.1023204200

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -73,6 +73,11 @@ spec:
             - name: LOG_BAILEYS
               value: "debug"
 
+            # WhatsApp Client Version (resolves Noise handshake failure)
+            - name: CONFIG_SESSION_PHONE_VERSION
+              value: "2.3000.1023204200"
+
+
 
           volumeMounts:
             - name: data


### PR DESCRIPTION
Overrides CONFIG_SESSION_PHONE_VERSION to a newer compatible version (2.3000.1023204200) to resolve connection failures during Noise handshake decryption setup in Baileys.