### PR TITLE
fix(whatsapp): upgrade evolution-api image to evoapicloud/evolution-api:v2.3.7

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: evolution-api
-          image: atendai/evolution-api:v2.1.1
+          image: evoapicloud/evolution-api:v2.3.7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Upgrades evolution-api container image to the latest open stable release (v2.3.7) to fix WhatsApp Web handshake connection issues caused by outdated Baileys library protocols.