### PR TITLE
Harden WhatsApp service network policies and logging levels

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -69,9 +69,9 @@ spec:
 
             # Logging Configurations
             - name: LOG_LEVEL
-              value: "ERROR,WARN,DEBUG,INFO,LOG,VERBOSE"
+              value: "ERROR,WARN"
             - name: LOG_BAILEYS
-              value: "debug"
+              value: "error"
 
             # WhatsApp Client Version (resolves Noise handshake failure)
             - name: CONFIG_SESSION_PHONE_VERSION

--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -45,9 +45,10 @@ spec:
               - matchPattern: "*.whatsapp.com"
               - matchPattern: "*.svc.cluster.local"
               
-    # 3. Allow outbound connections to the internet (for WhatsApp Web server connections, limited to port 443)
-    - toEntities:
-        - world
+    # 3. Allow outbound connections to WhatsApp servers (limited to port 443 over HTTPS/WSS)
+    - toFQDNs:
+        - matchPattern: "*.whatsapp.net"
+        - matchPattern: "*.whatsapp.com"
       toPorts:
         - ports:
             - port: "443"

--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -41,11 +41,17 @@ spec:
               protocol: TCP
           rules:
             dns:
-              - matchPattern: "*"
+              - matchPattern: "*.whatsapp.net"
+              - matchPattern: "*.whatsapp.com"
+              - matchPattern: "*.svc.cluster.local"
               
-    # 3. Allow outbound connections to the internet (for WhatsApp Web server connections)
+    # 3. Allow outbound connections to the internet (for WhatsApp Web server connections, limited to port 443)
     - toEntities:
         - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 
               
     # 4. Allow connecting to the local Postgres database


### PR DESCRIPTION
Restricts egress to world to port 443 TCP, limits DNS matching patterns to WhatsApp and local services, and lowers logging verbosity to ERROR/WARN.