### PR TITLE
Fix WhatsApp DNS matching patterns for database and n8n

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -44,6 +44,8 @@ spec:
               - matchPattern: "*.whatsapp.net"
               - matchPattern: "*.whatsapp.com"
               - matchPattern: "*.svc.cluster.local"
+              - matchPattern: "*.whatsapp"
+              - matchPattern: "*.n8n"
               
     # 3. Allow outbound connections to WhatsApp servers (limited to port 443 over HTTPS/WSS)
     - toFQDNs:


### PR DESCRIPTION
Adds *.whatsapp and *.n8n namespace suffixes to the DNS whitelist so the container can resolve short service names like whatsapp-db-rw.whatsapp and n8n.n8n.