### PR TITLE
Fix: wildcard DNS pattern to prevent K8s search domain timeouts

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/network-policy-evolution-api.yaml
@@ -41,11 +41,7 @@ spec:
               protocol: TCP
           rules:
             dns:
-              - matchPattern: "*.whatsapp.net"
-              - matchPattern: "*.whatsapp.com"
-              - matchPattern: "*.svc.cluster.local"
-              - matchPattern: "*.whatsapp"
-              - matchPattern: "*.n8n"
+              - matchPattern: "*"
               
     # 3. Allow outbound connections to WhatsApp servers (limited to port 443 over HTTPS/WSS)
     - toFQDNs:


### PR DESCRIPTION
Reverts DNS matchPattern to wildcard '*' so relative search path queries (like .cluster.local) don't get blocked and time out during resolution. Egress socket connection is still locked down via FQDN rules.