### PR TITLE
Use n8n test webhook endpoint temporarily for interactive building

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: WEBHOOK_GLOBAL_ENABLED
               value: "true"
             - name: WEBHOOK_GLOBAL_URL
-              value: "http://n8n.n8n.svc.cluster.local:5678/webhook/whatsapp-messages"
+              value: "http://n8n.n8n.svc.cluster.local:5678/webhook-test/whatsapp-messages"
             - name: WEBHOOK_GLOBAL_HEADERS
               value: '{"Content-Type": "application/json"}'
             


### PR DESCRIPTION
Updates WEBHOOK_GLOBAL_URL to point to the interactive testing URL (/webhook-test/whatsapp-messages) to assist in manually building the n8n workflow.