### PR TITLE
Use n8n production webhook endpoint for WhatsApp messaging

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: WEBHOOK_GLOBAL_ENABLED
               value: "true"
             - name: WEBHOOK_GLOBAL_URL
-              value: "http://n8n.n8n.svc.cluster.local:5678/webhook-test/whatsapp-messages"
+              value: "http://n8n.n8n.svc.cluster.local:5678/webhook/whatsapp-messages"
             - name: WEBHOOK_GLOBAL_HEADERS
               value: '{"Content-Type": "application/json"}'
             


### PR DESCRIPTION
Updates WEBHOOK_GLOBAL_URL back to the production URL (/webhook/whatsapp-messages) now that testing is complete.