### PR TITLE
Deploy dolores-brain v0.6.4

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/dolores-brain/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/dolores-brain/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: dolores-brain
-          image: ghcr.io/anchavesb/dolores-brain:v0.6.3
+          image: ghcr.io/anchavesb/dolores-brain:v0.6.4
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Bumps dolores-brain image tag to v0.6.4 to deploy the Cloudflare bypass fix.