### PR TITLE
[navy] Update ghcr.io/anchavesb/todo Docker tag to v0.7.1

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/todo/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/todo/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: todo
-          image: ghcr.io/anchavesb/todo:v0.7.0
+          image: ghcr.io/anchavesb/todo:v0.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: DATABASE_URL


### PR DESCRIPTION
Bumps todo Docker image tag to v0.7.1 following the merge of the cross-tab concurrency handling features.