### PR TITLE
feat: filter evolution-api webhook events to stop log noise

### DIFF
--- a/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-5/overlays/whatsapp/deployment.yaml
@@ -62,6 +62,8 @@ spec:
               value: '{"Content-Type": "application/json"}'
             
             # Enable specific events
+            - name: WEBHOOK_EVENTS_ALL
+              value: "false"
             - name: WEBHOOK_EVENTS_MESSAGES_UPSERT
               value: "true"
             - name: WEBHOOK_EVENTS_QRCODE_UPDATED


### PR DESCRIPTION
Disables sending all events by default in Evolution API and explicitly whitelists only messages.upsert and qrcode.updated to stop n8n webhook noise.