### PR TITLE
fix(traefik): allow GitHub egress for geoblock plugin and add Colombia (CO) to allowed countries

### DIFF
--- a/sites/indigo/clusters/dal-indigo-core-1/wave-2/overlays/traefik-public/middleware-geoblock.yaml
+++ b/sites/indigo/clusters/dal-indigo-core-1/wave-2/overlays/traefik-public/middleware-geoblock.yaml
@@ -20,6 +20,7 @@ spec:
       countries:
         - AU
         - NZ
+        - CO
 
       # Don't log happy path
       logAllowedRequests: false

--- a/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/anubis/ingress.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/anubis/ingress.yaml
@@ -2,11 +2,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: anubis
+  namespace: anubis
   annotations:
     cert-manager.io/cluster-issuer: dalmura-letsencrypt-prod
     external-dns.alpha.kubernetes.io/hostname: anubis.navy.dalmura.cloud
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: true
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-public-geoblock@kubernetescrd,traefik-public-ratelimit@kubernetescrd,traefik-public-security-headers@kubernetescrd
 spec:
   ingressClassName: ingress-public

--- a/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/traefik-public/middleware-geoblock.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/traefik-public/middleware-geoblock.yaml
@@ -20,6 +20,7 @@ spec:
       countries:
         - AU
         - NZ
+        - CO
 
       # Don't log happy path
       logAllowedRequests: false

--- a/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/traefik-public/network-policy-traefik.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-2/overlays/traefik-public/network-policy-traefik.yaml
@@ -47,6 +47,11 @@ spec:
               - matchPattern: "todo.todo"
               - matchPattern: "plugins.traefik.io"
               - matchPattern: "get.geojs.io"
+              - matchPattern: "*.github.com"
+              - matchPattern: "github.com"
+              - matchPattern: "raw.githubusercontent.com"
+              - matchPattern: "codeload.github.com"
+              - matchPattern: "api.github.com"
     - toEndpoints:
         # Namespaces that host services
         # Access within the namespace is managed by the namespace itself
@@ -61,3 +66,8 @@ spec:
     - toFQDNs:
         - matchName: "plugins.traefik.io"
         - matchName: "get.geojs.io"
+        - matchPattern: "*.github.com"
+        - matchName: "github.com"
+        - matchName: "raw.githubusercontent.com"
+        - matchName: "codeload.github.com"
+        - matchName: "api.github.com"

--- a/sites/navy/clusters/dal-navy-core-1/wave-3/overlays/authentik/ingress.yaml
+++ b/sites/navy/clusters/dal-navy-core-1/wave-3/overlays/authentik/ingress.yaml
@@ -2,13 +2,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: authentik
+  namespace: authentik
   annotations:
     cert-manager.io/cluster-issuer: dalmura-letsencrypt-prod
     external-dns.alpha.kubernetes.io/hostname: auth.navy.dalmura.cloud
     # Uncomment when we want to CNAME to public interface
     #external-dns.alpha.kubernetes.io/target: navy.dalmura.cloud
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: true
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.middlewares: traefik-public-geoblock@kubernetescrd,traefik-public-ratelimit@kubernetescrd,traefik-public-anubis@kubernetescrd,traefik-public-security-headers@kubernetescrd,authentik-authentik-csp@kubernetescrd
 spec:
   ingressClassName: ingress-public


### PR DESCRIPTION
## Summary
- Adds GitHub FQDNs (`github.com`, `raw.githubusercontent.com`, `codeload.github.com`, `api.github.com`) to CiliumNetworkPolicy egress rules for `traefik-public`, resolving startup download failures for the `PascalMinder/geoblock` Traefik plugin.
- Restores `traefik-public-geoblock@kubernetescrd` to ingress router annotations.
- Adds Colombia (`CO`) to the allowed countries list in `middleware-geoblock.yaml`.